### PR TITLE
fix: handle non-UTF-8 bytes in forkstat post-processor

### DIFF
--- a/forkstat-post-process
+++ b/forkstat-post-process
@@ -56,7 +56,7 @@ def main():
     current_ts = None
     counts = {}
 
-    with lzma.open(data_file, 'rt') as fh:
+    with lzma.open(data_file, 'rt', errors='replace') as fh:
         for line in fh:
             match = event_pattern.match(line)
             if not match:


### PR DESCRIPTION
## Summary

- Fix `UnicodeDecodeError` crash when forkstat output contains non-UTF-8 box-drawing characters
- Add `errors='replace'` to `lzma.open()` so undecodable bytes are substituted rather than crashing
- Safe because the regex parser only matches ASCII timestamp and event fields

## Test plan

- [ ] Verify forkstat post-processing completes without error
- [ ] Verify metric-data files are produced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)