### PR TITLE
docs: update CLAUDE.md to reflect Python post-processor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,18 +5,18 @@ Monitors process fork(), exec(), and exit() activity during benchmark execution 
 
 ## Languages
 - Bash: collection scripts (`forkstat-start`, `forkstat-stop`)
-- Perl: post-processor (`forkstat-post-process`)
+- Python: post-processor (`forkstat-post-process`)
 
 ## Key Files
 | File | Purpose |
 |------|---------|
 | `forkstat-start` | Launches forkstat with configurable `--events` parameter (default: `all`) |
 | `forkstat-stop` | Kills forkstat, compresses output with xz |
-| `forkstat-post-process` | Converts raw forkstat output to crucible metrics (uses `toolbox::metrics`, `toolbox::json`, `toolbox::cpu` from `$TOOLBOX_HOME/perl`) |
+| `forkstat-post-process` | Converts raw forkstat output to crucible metrics |
 | `rickshaw.json` | Rickshaw integration: endpoint allow/block lists, file deployment, post-process script |
 | `workshop.json` | Engine image build: compiles forkstat from source |
 
 ## Conventions
 - Primary branch is `main`
 - Runs as a profiler tool on master/worker roles, blocked on client/server
-- Standard Bash/Perl modelines and 4-space indentation
+- Standard Bash modelines and 4-space indentation


### PR DESCRIPTION
## Summary
- Update CLAUDE.md to reflect that post-processor is now Python, not Perl

🤖 Generated with [Claude Code](https://claude.com/claude-code)