### PR TITLE
fix: capture stderr, fix timezone mismatch, and CI filter

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -27,6 +27,7 @@ jobs:
             .github/workflows/run-crucible-tracking.yaml
             .github/workflows/crucible-ci.yaml
             .github/workflows/fork-check.yaml
+            .gitignore
             docs/**
       - name: Display changes
         run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .

--- a/forkstat-start
+++ b/forkstat-start
@@ -35,13 +35,13 @@ done
 
 /bin/rm -f forkstat-pids.txt
 
-# Record the UTC date for post-processing (forkstat only outputs HH:MM:SS)
-date -u +%Y-%m-%d > forkstat-date.txt
+# Record the local date for post-processing (forkstat outputs HH:MM:SS in local time)
+date +%Y-%m-%d > forkstat-date.txt
 
 cmd_path=$( command -v forkstat )
 cmd="$cmd_path -e ${events} -X -S"
 echo "About to run: ${cmd}"
-${cmd} > forkstat-stderrout.txt &
+${cmd} > forkstat-stderrout.txt 2>&1 &
 forkstat_pid=$!
 echo "${forkstat_pid}" >> forkstat-pids.txt
 echo "forkstat pid is ${forkstat_pid}"

--- a/forkstat-stop
+++ b/forkstat-stop
@@ -7,7 +7,7 @@ echo "hostname: `hostname`"
 
 if [ -e forkstat-pids.txt ]; then
     while read pid; do
-	echo "killing ${pid}"
+        echo "killing ${pid}"
         kill -s SIGINT $pid
     done < forkstat-pids.txt
 


### PR DESCRIPTION
## Summary

- Add missing `2>&1` redirect in `forkstat-start` so stderr is captured in the output file
- Change date recording from UTC to local time to match forkstat's timestamp output, preventing timezone mismatches in post-processing
- Fix tab indentation in `forkstat-stop`
- Add `.gitignore` to CI docs-only file filter

## Test plan

- [ ] forkstat stderr output captured in `forkstat-stderrout.txt`
- [ ] Post-processed timestamps are correct (no timezone offset)

Resolves https://github.com/perftool-incubator/tool-forkstat/issues/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)